### PR TITLE
🎛 ci: Enable macos CIs

### DIFF
--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -20,9 +20,9 @@ jobs:
             "git",
             "javascript",
             # "macos-alfred", # Script error to be fixed
-            # "macos-app-dev", # Depends on `git`
-            # "macos-app-private", # Depends on `git`
-            # "macos-app-work", # Depends on `git`
+            "macos-app-dev",
+            "macos-app-private",
+            "macos-app-work",
             "macos-appcleaner",
             "macos-brew",
             "macos-c-cpp",


### PR DESCRIPTION
These tests are previously disabled because they depends on `git`. Now that it is working, these checks should pass as well.