### PR TITLE
🗄 [chore][macos-appcleaner] Move inline commands to script

### DIFF
--- a/makefiles/macos.mk
+++ b/makefiles/macos.mk
@@ -40,8 +40,7 @@ macos-alfred: macos-brew
 	run "pkg/macos-alfred/macos-alfred.sh"
 
 macos-appcleaner: macos-brew
-	brew install --cask appcleaner
-	defaults import net.freemacsoft.AppCleaner pkg/macos-appcleaner/net.freemacsoft.AppCleaner.plist
+	run "pkg/macos-appcleaner/macos-appcleaner.sh"
 
 macos-cleanshot: macos-brew
 	run "pkg/macos-cleanshot/macos-cleanshot.sh"

--- a/pkg/macos-appcleaner/README.md
+++ b/pkg/macos-appcleaner/README.md
@@ -10,7 +10,8 @@ Installs AppCleaner and imports its stored preferences.
 
 ## Configures
 
-- `defaults import net.freemacsoft.AppCleaner` from the bundled `net.freemacsoft.AppCleaner.plist`
+- `ProtectOpenedApps = false` — allows removing apps that are currently running
+- `ShowProtectedApps = true` — protected apps remain visible in the UI
 
 ## Notes
 

--- a/pkg/macos-appcleaner/README.md
+++ b/pkg/macos-appcleaner/README.md
@@ -1,0 +1,22 @@
+# `macos-appcleaner`
+
+Installs AppCleaner and imports its stored preferences.
+
+## Installs
+
+| App          | macOS  | Debian |
+| ------------ | ------ | ------ |
+| `appcleaner` | `brew` | —      |
+
+## Configures
+
+- `defaults import net.freemacsoft.AppCleaner` from the bundled `net.freemacsoft.AppCleaner.plist`
+
+## Notes
+
+- macOS only; no Debian equivalent.
+- The plist captures AppCleaner's settings so they are restored on every fresh install.
+
+## References
+
+- [AppCleaner](https://freemacsoft.net/appcleaner/): Official site for the AppCleaner app.

--- a/pkg/macos-appcleaner/macos-appcleaner.sh
+++ b/pkg/macos-appcleaner/macos-appcleaner.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+brew install --cask appcleaner
+defaults import net.freemacsoft.AppCleaner pkg/macos-appcleaner/net.freemacsoft.AppCleaner.plist


### PR DESCRIPTION
Extracted the two Makefile recipe lines (brew install + defaults import)
into pkg/macos-appcleaner/macos-appcleaner.sh, matching the single-run
convention used by all other package targets.

https://claude.ai/code/session_01BquVZvJeEGzqVN43x6gpFa