### PR TITLE
📖 [docs][docker] README

### DIFF
--- a/pkg/docker/README.md
+++ b/pkg/docker/README.md
@@ -1,0 +1,23 @@
+# `docker`
+
+Installs Docker Desktop and Hadolint (Dockerfile linter) on macOS.
+
+## Installs
+
+| Tool       | macOS  | Debian |
+| ---------- | ------ | ------ |
+| `docker`   | `brew` | —      |
+| `hadolint` | `brew` | —      |
+
+> Docker Desktop is installed as a cask; `hadolint` is a Homebrew formula.
+
+## Configures
+
+No configuration files are managed by this package.
+
+## Notes
+
+- macOS only — no Debian target exists.
+- Invoke via `make macos-docker`.
+- Docker Desktop bundles `docker`, `docker compose`, and the Docker daemon; no separate CLI install is needed.
+- `hadolint` lints Dockerfiles against best practices and the official Dockerfile reference.


### PR DESCRIPTION
## Summary
Added a new `docker` package documentation file that describes the installation and configuration of Docker Desktop and Hadolint on macOS.

## Changes
- Created `pkg/docker/README.md` with comprehensive package documentation including:
  - Overview of the package purpose (Docker Desktop and Hadolint installation on macOS)
  - Installation matrix showing tool availability by platform
  - Notes on Docker Desktop bundling and Hadolint's linting capabilities
  - Platform-specific information (macOS only, invoked via `make macos-docker`)

## Details
The documentation follows the established package documentation pattern and clearly communicates that this is a macOS-only package with no Debian support. It explains that Docker Desktop is installed as a Homebrew cask while Hadolint is installed as a formula, and notes that Docker Desktop bundles all necessary Docker CLI tools.

https://claude.ai/code/session_015enMAVSMtxAVJmkPMSKCFj